### PR TITLE
Setup Azure Pipelines for Mac and Windows

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -100,6 +100,13 @@ jobs:
   - bash: source continuous-integration/azure/setup-miniconda.sh
     displayName: Setup Miniconda
 
+  # Utilities for using pytest on Azure
+  - bash: |
+      set -x -e
+      source activate testing
+      pip install pytest-azurepipelines
+    displayName: Install pytest-azurepipelines
+
   # Show installed pkg information for postmortem diagnostic
   - bash: |
       set -x -e
@@ -176,6 +183,13 @@ jobs:
   # Setup dependencies and build a conda environment
   - script: continuous-integration/azure/setup-miniconda.bat
     displayName: Setup Miniconda
+
+  # Utilities for using pytest on Azure
+  - bash: |
+      set -x -e
+      source activate testing
+      pip install pytest-azurepipelines
+    displayName: Install pytest-azurepipelines
 
   # Show installed pkg information for postmortem diagnostic
   - bash: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,212 @@
+# Configuration for Azure Pipelines
+########################################################################################
+
+# Only build the master branch, tags, and PRs (on by default) to avoid building random
+# branches in the repository until a PR is opened.
+trigger:
+  branches:
+    include:
+    - master
+    - refs/tags/*
+
+
+jobs:
+
+# Linux
+########################################################################################
+- job:
+  displayName: 'Style Checks'
+
+  pool:
+    vmImage: 'ubuntu-16.04'
+
+  variables:
+    CONDA_INSTALL_EXTRA: "black flake8 pylint"
+    PYTHON: '3.7'
+
+  steps:
+
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.7'
+
+  - bash: echo "##vso[task.prependpath]/usr/share/miniconda/bin"
+    displayName: Add conda to PATH
+
+  # Get the Fatiando CI scripts
+  - bash: git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
+    displayName: Fetch the Fatiando CI scripts
+
+  # Setup dependencies and build a conda environment
+  - bash: source continuous-integration/azure/setup-miniconda.sh
+    displayName: Setup Miniconda
+
+  # Show installed pkg information for postmortem diagnostic
+  - bash: |
+      set -x -e
+      source activate testing
+      conda list
+    displayName: List installed packages
+
+  # Check that the code passes format checks
+  - bash: |
+      set -x -e
+      source activate testing
+      make check
+    displayName: Formatting check (black and flake8)
+    condition: succeededOrFailed()
+
+  # Check that the code passes linting checks
+  - bash: |
+      set -x -e
+      source activate testing
+      make lint
+    displayName: Linting (pylint)
+    condition: succeededOrFailed()
+
+
+# Mac
+########################################################################################
+- job:
+  displayName: 'Mac'
+
+  pool:
+    vmImage: 'macOS-10.13'
+
+  variables:
+    CONDA_REQUIREMENTS: requirements.txt
+    CONDA_REQUIREMENTS_DEV: requirements-dev.txt
+    CONDA_INSTALL_EXTRA: "codecov"
+
+  strategy:
+    matrix:
+      Python37:
+        python.version: '3.7'
+        PYTHON: '3.7'
+      Python36:
+        python.version: '3.6'
+        PYTHON: '3.6'
+
+  steps:
+
+  - bash: echo "##vso[task.prependpath]$CONDA/bin"
+    displayName: Add conda to PATH
+
+  # Get the Fatiando CI scripts
+  - bash: git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
+    displayName: Fetch the Fatiando CI scripts
+
+  # Setup dependencies and build a conda environment
+  - bash: source continuous-integration/azure/setup-miniconda.sh
+    displayName: Setup Miniconda
+
+  # Show installed pkg information for postmortem diagnostic
+  - bash: |
+      set -x -e
+      source activate testing
+      conda list
+    displayName: List installed packages
+
+  # Install the package
+  - bash: |
+      set -x -e
+      source activate testing
+      python setup.py bdist_wheel
+      pip install dist/*
+    displayName: Install the package
+
+  # Run the tests
+  - bash: |
+      set -x -e
+      source activate testing
+      make test
+    displayName: Test
+
+  # Build the documentation
+  - bash: |
+      set -x -e
+      source activate testing
+      make -C doc clean all
+    displayName: Build the documentation
+
+  # Upload test coverage if there were no failures
+  - bash: |
+      set -x -e
+      source activate testing
+      coverage xml
+      echo "Uploading coverage to Codecov"
+      codecov -e PYTHON AGENT_OS
+    env:
+      CODECOV_TOKEN: $(codecov.token)
+    condition: succeeded()
+    displayName: Upload coverage
+
+
+# Windows
+########################################################################################
+- job:
+  displayName: 'Windows'
+
+  pool:
+    vmImage: 'vs2017-win2016'
+
+  variables:
+    CONDA_REQUIREMENTS: requirements.txt
+    CONDA_REQUIREMENTS_DEV: requirements-dev.txt
+    CONDA_INSTALL_EXTRA: "codecov"
+
+  strategy:
+    matrix:
+      Python37:
+        python.version: '3.7'
+        PYTHON: '3.7'
+      Python36:
+        python.version: '3.6'
+        PYTHON: '3.6'
+
+  steps:
+
+  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+    displayName: Add conda to PATH
+
+  # Get the Fatiando CI scripts
+  - script: git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
+    displayName: Fetch the Fatiando CI scripts
+
+  # Setup dependencies and build a conda environment
+  - script: continuous-integration/azure/setup-miniconda.bat
+    displayName: Setup Miniconda
+
+  # Show installed pkg information for postmortem diagnostic
+  - bash: |
+      set -x -e
+      source activate testing
+      conda list
+    displayName: List installed packages
+
+  # Install the package that we want to test
+  - bash: |
+      set -x -e
+      source activate testing
+      python setup.py sdist --formats=zip
+      pip install dist/*
+    displayName: Install the package
+
+  # Run the tests
+  - bash: |
+      set -x -e
+      source activate testing
+      make test
+    displayName: Test
+
+  # Upload test coverage if there were no failures
+  - bash: |
+      set -x -e
+      source activate testing
+      coverage report -m
+      coverage xml
+      codecov -e PYTHON AGENT_OS
+    env:
+      CODECOV_TOKEN: $(codecov.token)
+    condition: succeeded()
+    displayName: Upload coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,48 +32,29 @@ env:
         - CONDA_REQUIREMENTS=requirements.txt
         - CONDA_REQUIREMENTS_DEV=requirements-dev.txt
         # These variables control which actions are performed in a build
-        - TEST=false
-        - CHECK=false
-        - BUILD_DOCS=false
         - DEPLOY_DOCS=false
         - DEPLOY_PYPI=false
 
 # Specify the build configurations. Be sure to only deploy from a single build.
 matrix:
     include:
-        # Code style and quality checks
-        - name: "Style checks"
+        - name: "Linux - Python 3.7"
           os: linux
           env:
-              - PYTHON=3.6
-              - CHECK=true
-              # Don't need to install everything just to run the style checks
-              - CONDA_INSTALL_EXTRA="black flake8 pylint=2.2.2"
-              - CONDA_REQUIREMENTS=""
-              - CONDA_REQUIREMENTS_DEV=""
+              - PYTHON=3.7
         # Main build to deploy to PyPI and Github pages
         - name: "Linux - Python 3.6 (deploy)"
           os: linux
           env:
               - PYTHON=3.6
-              - TEST=true
-              - BUILD_DOCS=true
               - DEPLOY_DOCS=true
               - DEPLOY_PYPI=true
-        - name: "Mac - Python 3.6"
-          os: osx
-          env:
-              - PYTHON=3.6
-              - TEST=true
-              - BUILD_DOCS=true
-              # To get all dependencies for rasterio
-              - CONDA_EXTRA_CHANNEL=defaults
 
 # Setup the build environment
 before_install:
     # Copy sample data to the verde data dir to avoid downloading all the time
     # Get the Fatiando CI scripts
-    - git clone --branch=1.0.0 --depth=1 https://github.com/fatiando/continuous-integration.git
+    - git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
     # Download and install miniconda and setup dependencies
     # Need to source the script to set the PATH variable globaly
     - source continuous-integration/travis/setup-miniconda.sh
@@ -88,29 +69,17 @@ install:
 
 # Run the actual tests and checks
 script:
-    # Check code for style and quality
-    - if [ "$CHECK" == "true" ]; then
-          make check;
-          make lint;
-      fi
     # Run the test suite
-    - if [ "$TEST" == "true" ]; then
-          pip install codecov;
-          make test;
-      fi
+    - make test
     # Build the documentation
-    - if [ "$BUILD_DOCS" == "true" ]; then
-          make -C doc clean all;
-      fi
+    - make -C doc clean all
 
 # Things to do if the build is successful
 after_success:
     # Upload coverage information
-    - if [ "$TEST" == "true" ]; then
-        coverage xml;
-        echo "Uploading coverage to Codecov";
-        codecov -e PYTHON;
-      fi
+    - coverage xml
+    - echo "Uploading coverage to Codecov"
+    - codecov -e PYTHON
 
 # Deploy
 deploy:

--- a/README.rst
+++ b/README.rst
@@ -18,9 +18,12 @@ Part of the `Fatiando a Terra <https://www.fatiando.org>`__ project
 .. image:: http://img.shields.io/pypi/v/rockhound.svg?style=flat-square
     :alt: Latest version on PyPI
     :target: https://pypi.python.org/pypi/rockhound
-.. image:: http://img.shields.io/travis/fatiando/rockhound/master.svg?style=flat-square&label=Linux|Mac
+.. image:: http://img.shields.io/travis/fatiando/rockhound/master.svg?style=flat-square&label=TravisCI
     :alt: TravisCI build status
     :target: https://travis-ci.org/fatiando/rockhound
+.. image:: https://img.shields.io/azure-devops/build/fatiando/c64572de-afef-44c5-86a8-212dce3e0a5c/8/master.svg?label=Azure&style=flat-square
+    :alt: Azure Pipelines build status
+    :target: https://dev.azure.com/fatiando/rockhound/_build
 .. image:: https://img.shields.io/codecov/c/github/fatiando/rockhound/master.svg?style=flat-square
     :alt: Test coverage status
     :target: https://codecov.io/gh/fatiando/rockhound

--- a/rockhound/bedmap2.py
+++ b/rockhound/bedmap2.py
@@ -21,9 +21,7 @@ DATASETS = [
     "coverage",
     "geoid",
 ]
-DATASET_FILES = {
-    dataset: "bedmap2_{}.tif".format(dataset) for dataset in DATASETS
-}
+DATASET_FILES = {dataset: "bedmap2_{}.tif".format(dataset) for dataset in DATASETS}
 DATASET_FILES["geoid"] = "gl04c_geiod_to_WGS84.tif"
 
 
@@ -97,8 +95,7 @@ def fetch_bedmap2(datasets, load=True):
             with ZipFile(fname, "r") as zip_file:
                 # The paths in the zip file aren't following OS conventions
                 zip_file.extract(
-                    "/".join(["bedmap2_tiff", DATASET_FILES[dataset]]),
-                    path=tempdir,
+                    "/".join(["bedmap2_tiff", DATASET_FILES[dataset]]), path=tempdir
                 )
             array = xr.open_rasterio(
                 os.path.join(tempdir, "bedmap2_tiff", DATASET_FILES[dataset])

--- a/rockhound/bedmap2.py
+++ b/rockhound/bedmap2.py
@@ -21,6 +21,10 @@ DATASETS = [
     "coverage",
     "geoid",
 ]
+DATASET_FILES = {
+    dataset: "bedmap2_{}.tif".format(dataset) for dataset in DATASETS
+}
+DATASET_FILES["geoid"] = "gl04c_geiod_to_WGS84.tif"
 
 
 def fetch_bedmap2(datasets, load=True):
@@ -28,7 +32,7 @@ def fetch_bedmap2(datasets, load=True):
     Fetch the Bedmap2 datasets for Antarctica.
 
     Bedmap2 is a suite of gridded products describing surface elevation,
-    ice-thickness, the sea ﬂoor and subglacial bed elevation of the Antarctic south
+    ice-thickness, the sea floor and subglacial bed elevation of the Antarctic south
     of 60°S [BEDMAP2]_.
     The datasets are downloaded as ``tiff`` files and loaded into a
     :class:`xarray.Dataset` object.
@@ -85,22 +89,19 @@ def fetch_bedmap2(datasets, load=True):
         raise ValueError(
             "Invalid datasets: {}".format(set(datasets).difference(DATASETS))
         )
-    available_datasets = {
-        dataset: "bedmap2_{}.tif".format(dataset) for dataset in DATASETS
-    }
-    available_datasets["geoid"] = "gl04c_geiod_to_WGS84.tif"
     grid = []
     for dataset in datasets:
         with tempfile.TemporaryDirectory() as tempdir:
             # Decompress the file into a temporary file so we can load it with xr
             # The .tif files inside the zip are located inside a bedmap2_tiff directory
             with ZipFile(fname, "r") as zip_file:
+                # The paths in the zip file aren't following OS conventions
                 zip_file.extract(
-                    os.path.join("bedmap2_tiff", available_datasets[dataset]),
+                    "/".join(["bedmap2_tiff", DATASET_FILES[dataset]]),
                     path=tempdir,
                 )
             array = xr.open_rasterio(
-                os.path.join(tempdir, "bedmap2_tiff", available_datasets[dataset])
+                os.path.join(tempdir, "bedmap2_tiff", DATASET_FILES[dataset])
             )
             # Replace no data values with nans
             array = array.where(array != array.nodatavals)

--- a/rockhound/bedmap2.py
+++ b/rockhound/bedmap2.py
@@ -97,9 +97,12 @@ def fetch_bedmap2(datasets, load=True):
                 zip_file.extract(
                     "/".join(["bedmap2_tiff", DATASET_FILES[dataset]]), path=tempdir
                 )
+            # Make sure the data are loaded into memory and not linked to file
             array = xr.open_rasterio(
                 os.path.join(tempdir, "bedmap2_tiff", DATASET_FILES[dataset])
-            )
+            ).load()
+            # Close any files associated with this dataset to make sure can delete them
+            array.close()
             # Replace no data values with nans
             array = array.where(array != array.nodatavals)
             # Remove "band" dimension and coordinate

--- a/rockhound/etopo1.py
+++ b/rockhound/etopo1.py
@@ -61,7 +61,10 @@ def fetch_etopo1(version, load=True, **kwargs):
             # Decompress the file into a temporary file so we can load it with xarray
             with gzip.open(fname) as unzipped:
                 shutil.copyfileobj(unzipped, temporary)
-        grid = xr.open_dataset(temporary.name, **kwargs)
+        # Make sure the data are loaded into memory and not linked to file
+        grid = xr.open_dataset(temporary.name, **kwargs).load()
+        # Close any files associated with this dataset to make sure can delete them
+        grid.close()
     finally:
         os.remove(temporary.name)
     # Add more metadata and fix some names

--- a/rockhound/prem.py
+++ b/rockhound/prem.py
@@ -1,8 +1,9 @@
 """
 Load the Preliminary Reference Earth Model (PREM) dataset.
 """
-import numpy as np
 import pandas as pd
+import numpy as np
+
 from .registry import REGISTRY
 
 

--- a/rockhound/tests/test_bedmap2.py
+++ b/rockhound/tests/test_bedmap2.py
@@ -1,8 +1,8 @@
 """
 Test the Bedmap2 loading function.
 """
-import numpy as np
 import pytest
+import numpy as np
 
 from .. import fetch_bedmap2
 from ..bedmap2 import DATASETS


### PR DESCRIPTION
Use v1.1.1 of the Fatiando CI scripts and setup Mac and Windows builds
on Azure Pipelines. Move the style checks to Azure since it's faster
than Travis. Build on Python 3.6 and 3.7.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
