### PR TITLE
Use https in README to fix browsers complaints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ doc/sample_data
 MANIFEST
 dask-worker-space
 .coverage.*
+.tmp-test-dir-with-unique-name/

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ test:
 	mkdir -p $(TESTDIR)
 	cd $(TESTDIR); MPLBACKEND='agg' pytest $(PYTEST_ARGS) $(PROJECT)
 	cp $(TESTDIR)/.coverage* .
-	rm -rvf $(TESTDIR)
+	# Make sure always returns 0 to avoid breaking builds in CIs when it fails
+	rm -rvf $(TESTDIR) || true
 
 format:
 	black $(BLACK_FILES)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Build, package, test, and clean
 PROJECT=rockhound
-TESTDIR=tmp-test-dir-with-unique-name
+TESTDIR=.tmp-test-dir-with-unique-name
 PYTEST_ARGS=--cov-config=../.coveragerc --cov-report=term-missing --cov=$(PROJECT) --doctest-modules -v --pyargs
 LINT_FILES=setup.py $(PROJECT)
 BLACK_FILES=setup.py $(PROJECT) examples
@@ -25,8 +25,6 @@ test:
 	mkdir -p $(TESTDIR)
 	cd $(TESTDIR); MPLBACKEND='agg' pytest $(PYTEST_ARGS) $(PROJECT)
 	cp $(TESTDIR)/.coverage* .
-	# Make sure always returns 0 to avoid breaking builds in CIs when it fails
-	rm -rvf $(TESTDIR) || true
 
 format:
 	black $(BLACK_FILES)

--- a/README.rst
+++ b/README.rst
@@ -10,15 +10,15 @@ RockHound
     ¹ `Merriam Webster dictionary <https://www.merriam-webster.com/dictionary/rock%20hound>`__ |
     ² Not a real dictionary definition.
 
-`Documentation <http://www.fatiando.org/rockhound>`__ |
-`Documentation (dev version) <http://www.fatiando.org/rockhound/dev>`__ |
+`Documentation <https://www.fatiando.org/rockhound>`__ |
+`Documentation (dev version) <https://www.fatiando.org/rockhound/dev>`__ |
 `Contact <https://gitter.im/fatiando/fatiando>`__ |
 Part of the `Fatiando a Terra <https://www.fatiando.org>`__ project
 
-.. image:: http://img.shields.io/pypi/v/rockhound.svg?style=flat-square
+.. image:: https://img.shields.io/pypi/v/rockhound.svg?style=flat-square
     :alt: Latest version on PyPI
     :target: https://pypi.python.org/pypi/rockhound
-.. image:: http://img.shields.io/travis/fatiando/rockhound/master.svg?style=flat-square&label=TravisCI
+.. image:: https://img.shields.io/travis/fatiando/rockhound/master.svg?style=flat-square&label=TravisCI
     :alt: TravisCI build status
     :target: https://travis-ci.org/fatiando/rockhound
 .. image:: https://img.shields.io/azure-devops/build/fatiando/c64572de-afef-44c5-86a8-212dce3e0a5c/8/master.svg?label=Azure&style=flat-square
@@ -145,6 +145,6 @@ of the **BSD 3-clause License**. A copy of this license is provided in
 Documentation for other versions
 --------------------------------
 
-* `Development <http://www.fatiando.org/rockhound/dev>`__ (reflects the *master* branch on
+* `Development <https://www.fatiando.org/rockhound/dev>`__ (reflects the *master* branch on
   Github)
-* `Latest release <http://www.fatiando.org/rockhound/latest>`__
+* `Latest release <https://www.fatiando.org/rockhound/latest>`__


### PR DESCRIPTION
The badges were served with http instead of https resulting in browsers
complaining of mixed content being served.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
