### PR TITLE
Update Pooch and read requirements from file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,5 @@ include CONTRIBUTING.md
 include MAINTENANCE.md
 include AUTHORS.md
 include versioneer.py
+include requirements.txt
 include rockhound/registry.txt

--- a/environment.yml
+++ b/environment.yml
@@ -3,9 +3,9 @@ channels:
     - conda-forge
     - defaults
 dependencies:
-    - python=3.6
+    - python=3.7
     - pip
-    - pooch
+    - pooch>=0.4
     - xarray
     - pandas
     - rasterio

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pooch
+pooch>=0.4
 xarray
 pandas
 rasterio

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ PLATFORMS = "Any"
 PACKAGES = find_packages(exclude=["doc"])
 SCRIPTS = []
 PACKAGE_DATA = {"rockhound": ["registry.txt"]}
-INSTALL_REQUIRES = ["pooch", "xarray", "pandas", "rasterio"]
+with open("requirements.txt") as f:
+    INSTALL_REQUIRES = f.readlines()
 PYTHON_REQUIRES = ">=3.6"
 
 if __name__ == "__main__":


### PR DESCRIPTION
Read from the `requirements.txt` in `setup.py` instead of having to
remember to change things in both.
Require `pooch>=0.4` so we can use the new hooks for unzipping.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.