### PR TITLE
Add Bedmap2 example and use cmocean colormaps

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -27,6 +27,7 @@ Dependencies
 Most of the examples in the :ref:`gallery` also use:
 
 * `matplotlib <https://matplotlib.org/>`__
+* `cmocean <https://matplotlib.org/cmocean/>`__ for beautiful colormaps
 * `cartopy <https://scitools.org.uk/cartopy/>`__ for plotting maps
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
     - rasterio
     # Development requirements
     - matplotlib
+    - cmocean
     - cartopy
     - pytest
     - pytest-cov

--- a/examples/bedmap2.py
+++ b/examples/bedmap2.py
@@ -1,0 +1,27 @@
+"""
+Bedmap2
+=======
+
+Bedmap2 is a suite of gridded products describing surface elevation, ice-thickness, the
+sea floor and subglacial bed elevation of the Antarctic south of 60°S [BEDMAP2]_.
+Each dataset is projected in Antarctic Polar Stereographic projection, latitude of true
+scale -71 degrees south, datum WGS84. All heights are in metres relative to sea level as
+defined by the g104c geoid. The datasets are downloaded as ``tiff`` files and loaded
+into a :class:`xarray.Dataset` object.
+"""
+import rockhound as rh
+import matplotlib.pyplot as plt
+import cmocean
+
+# Load the ice thickness grid
+bedmap = rh.fetch_bedmap2(datasets=["thickness"])
+# bedmap = bedmap.sel(x=slice(None, 0), y=slice(0, None))
+print(bedmap)
+
+plt.figure(figsize=(8, 9.5))
+ax = plt.subplot(111)
+pc = bedmap.thickness.plot.pcolormesh(ax=ax, cmap=cmocean.cm.ice, add_colorbar=False)
+plt.colorbar(pc, ax=ax, orientation="horizontal", pad=0.05, aspect=50, label="meters")
+ax.set_title("Bedmap2 Antarctica Ice Thickness")
+plt.tight_layout()
+plt.show()

--- a/examples/etopo1.py
+++ b/examples/etopo1.py
@@ -11,6 +11,7 @@ and make computations.
 import rockhound as rh
 import matplotlib.pyplot as plt
 import cartopy.crs as ccrs
+import cmocean
 
 # Load both the ice surface and bedrock grids and merge them into a single Dataset
 grid = rh.fetch_etopo1(version="ice")
@@ -27,7 +28,9 @@ trans = ccrs.PlateCarree()
 
 # Setup some common arguments for the colorbar and pseudo-color plot
 cbar_kwargs = dict(pad=0, orientation="horizontal")
-pcolor_args = dict(cmap="terrain", add_colorbar=False, transform=ccrs.PlateCarree())
+pcolor_args = dict(
+    cmap=cmocean.cm.topo, add_colorbar=False, transform=ccrs.PlateCarree()
+)
 
 # Draw the maps
 fig, axes = plt.subplots(1, 2, figsize=(9, 5), subplot_kw=dict(projection=proj))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-# Development requirements
 matplotlib
+cmocean
 cartopy
 pytest
 pytest-cov


### PR DESCRIPTION
The topo and ice colormaps are nicer than the matplotlib defaults.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.