### PR TITLE
Use Pooch's unzip hook with bedmap2

### DIFF
--- a/rockhound/bedmap2.py
+++ b/rockhound/bedmap2.py
@@ -90,7 +90,7 @@ def fetch_bedmap2(datasets, load=True):
     arrays = []
     for dataset in datasets:
         for fname in fnames:
-            if fname.endswith(DATASET_FILES[dataset]):
+            if os.path.basename(fname) == DATASET_FILES[dataset]:
                 array = xr.open_rasterio(fname)
                 # Replace no data values with nans
                 array = array.where(array != array.nodatavals)

--- a/rockhound/tests/test_bedmap2.py
+++ b/rockhound/tests/test_bedmap2.py
@@ -5,7 +5,6 @@ import pytest
 import numpy as np
 
 from .. import fetch_bedmap2
-from ..bedmap2 import DATASETS
 
 
 def test_bedmap2_invalid_dataset():
@@ -16,8 +15,14 @@ def test_bedmap2_invalid_dataset():
 
 def test_bedmap2_file_name_only():
     "Only fetch the file name."
-    name = fetch_bedmap2(datasets=None, load=False)
-    assert name.endswith("bedmap2_tiff.zip")
+    names = fetch_bedmap2(datasets=["bed"], load=False)
+    assert len(names) == 1
+    assert names[0].endswith("bedmap2_bed.tif")
+    names = fetch_bedmap2(datasets=["thickness", "surface", "geoid"], load=False)
+    assert len(names) == 3
+    assert names[0].endswith("bedmap2_thickness.tif")
+    assert names[1].endswith("bedmap2_surface.tif")
+    assert names[2].endswith("gl04c_geiod_to_WGS84.tif")
 
 
 def test_bedmap2_datasets_as_str():

--- a/rockhound/tests/test_bedmap2.py
+++ b/rockhound/tests/test_bedmap2.py
@@ -22,9 +22,8 @@ def test_bedmap2_file_name_only():
 
 def test_bedmap2_datasets_as_str():
     "Datasets argument passed as strings"
-    for dataset in DATASETS:
-        grid = fetch_bedmap2(dataset)
-        assert set(grid.data_vars) == set([dataset])
+    grid = fetch_bedmap2("bed")
+    assert set(grid.data_vars) == set(["bed"])
 
 
 def test_bedmap2_multiple_datasets():


### PR DESCRIPTION
Let Pooch unzip the archive and store the unzipped version in the data directory.
Speeds up loading the data a bit because we avoid unzipping all the time.
Allows users to get the path to the datasets they want on disk as well.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.