### PR TITLE
Use a decompression processor for ETOPO1

### DIFF
--- a/rockhound/tests/test_etopo1.py
+++ b/rockhound/tests/test_etopo1.py
@@ -15,9 +15,9 @@ def test_etopo1_invalid_version():
 def test_etopo1_file_name_only():
     "Only fetch the file name."
     name = fetch_etopo1(version="ice", load=False)
-    assert name.endswith("ETOPO1_Ice_g_gmt4.grd.gz")
+    assert name.endswith("ETOPO1_Ice_g_gmt4.grd")
     name = fetch_etopo1(version="bedrock", load=False)
-    assert name.endswith("ETOPO1_Bed_g_gmt4.grd.gz")
+    assert name.endswith("ETOPO1_Bed_g_gmt4.grd")
 
 
 def test_etopo1():


### PR DESCRIPTION
Create a Pooch processor that decompresses the ETOPO1 grid so that we
can load it in xarray without having to load everything into memory.


<!-- Please describe changes proposed and WHY you made them. If unsure, open an issue first to discuss the idea. -->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #20


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.