### PR TITLE
Add the age of the oceanic lithosphere grids

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -14,6 +14,7 @@ API Reference
     fetch_etopo1
     fetch_prem
     fetch_bedmap2
+    fetch_seafloor_age
 
 
 Utilities

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -74,7 +74,7 @@ master_doc = 'index'
 
 # General information about the project
 year = datetime.date.today().year
-project = 'rockhound'
+project = 'RockHound'
 copyright = '2018-{}, The RockHound Developers'.format(year)
 if len(full_version.split('+')) > 1 or full_version == 'unknown':
     version = 'dev'

--- a/doc/references.rst
+++ b/doc/references.rst
@@ -3,5 +3,6 @@ References
 
 .. [AmanteEakins2009] Amante, C. and B.W. Eakins, 2009. ETOPO1 1 Arc-Minute Global Relief Model: Procedures, Data Sources and Analysis. NOAA Technical Memorandum NESDIS NGDC-24. National Geophysical Data Center, NOAA. doi:10.7289/V5C8276M
 .. [Dziewonsky1981] Dziewonski, A.M., and D.L. Anderson. 1981. “Preliminary reference Earth model.” Phys. Earth Plan. Int. 25:297-356.
-.. [IRIS2011] IRIS DMC (2011), Data Services Products: EMC, A repository of Earth models, https://doi.org/10.17611/DP/EMC.1.
-.. [BEDMAP2] Fretwell, P. et al. (2013). Bedmap2: improved ice bed, surface and thickness datasets for Antarctica. The Cryosphere. https://doi.org/10.5194/tc-7-375-2013
+.. [IRIS2011] IRIS DMC (2011), Data Services Products: EMC, A repository of Earth models, doi:10.17611/DP/EMC.1.
+.. [BEDMAP2] Fretwell, P. et al. (2013). Bedmap2: improved ice bed, surface and thickness datasets for Antarctica. The Cryosphere. doi:10.5194/tc-7-375-2013
+.. [Muller2008] Müller, R. D., Sdrolias, M., Gaina, C., & Roest, W. R. (2008). Age, spreading rates, and spreading asymmetry of the world’s ocean crust. Geochemistry, Geophysics, Geosystems, 9(4). doi:10.1029/2007GC001743

--- a/examples/seafloor_age.py
+++ b/examples/seafloor_age.py
@@ -1,0 +1,27 @@
+"""
+Age of the Oceanic Lithosphere
+==============================
+
+Global grids of the age of the oceanic lithosphere produced by [Muller2008]_.
+Available in 2 and 6 arc-minute resolutions and include grids of the age uncertainty.
+More information at the
+`NOAA NCEI <https://www.ngdc.noaa.gov/mgg/ocean_age/ocean_age_2008.html>`__ and
+`EarthByte <http://www.earthbyte.org/age-spreading-rates-and-spreading-asymmetry-of-the-worlds-ocean-crust/>`__
+websites.
+"""
+import rockhound as rh
+import matplotlib.pyplot as plt
+import cmocean
+
+# Load the age and uncertainty grids in the default 6 arc-minute resolution
+grid = rh.fetch_seafloor_age()
+print(grid)
+
+# Plot the age grid.
+# We're not using a map projection to speed up the plotting but this NOT recommended.
+plt.figure(figsize=(9, 5))
+grid.age.plot.pcolormesh(
+    cmap=cmocean.cm.thermal_r, cbar_kwargs=dict(pad=0.01, aspect=30)
+)
+plt.tight_layout()
+plt.show()

--- a/rockhound/__init__.py
+++ b/rockhound/__init__.py
@@ -4,6 +4,7 @@ from . import version
 from .etopo1 import fetch_etopo1
 from .prem import fetch_prem
 from .bedmap2 import fetch_bedmap2
+from .seafloor import fetch_seafloor_age
 
 
 # Get the version number through versioneer

--- a/rockhound/registry.txt
+++ b/rockhound/registry.txt
@@ -2,3 +2,7 @@ ETOPO1_Ice_g_gmt4.grd.gz c241db385d89f3d0c22eec8138224db9f2ebee6a1b4d1ecb4ebc6a5
 ETOPO1_Bed_g_gmt4.grd.gz e5dd1e07c9039a966096d658976145b34a7006613ba32c7e898d26dd1dd3e1d9 https://www.ngdc.noaa.gov/mgg/global/relief/ETOPO1/data/bedrock/grid_registered/netcdf/ETOPO1_Bed_g_gmt4.grd.gz
 PREM_1s.csv 71e5d8883e5ee0529c7d8f02c8e68d12c350e993bdbd106a3697c64fa3bf9faa https://ds.iris.edu/files/products/emc/data/PREM/PREM_1s.csv
 bedmap2_tiff.zip f4bb27ce05197e9d29e4249d64a947b93aab264c3b4e6cbf49d6b339fb6c67fe https://secure.antarctica.ac.uk/data/bedmap2/bedmap2_tiff.zip
+age.3.2.nc.bz2 49003831db78f7bb044532daf31fdc49218f75876668ee0c96877f383214b827 https://www.ngdc.noaa.gov/mgg/ocean_age/data/2008/grids/age/age.3.2.nc.bz2
+age.3.6.nc.bz2 c99358e4a980be15f05df71506d9337dc760d32e5907f9526bc8135224fc1f81 https://www.ngdc.noaa.gov/mgg/ocean_age/data/2008/grids/age/age.3.6.nc.bz2
+ageerror.3.2.nc.bz2 fd599a02488912e6d3bc53fc1e658f3d116a893201c0c9fb5e496c4020279a35 https://www.ngdc.noaa.gov/mgg/ocean_age/data/2008/grids/age_error/ageerror.3.2.nc.bz2
+ageerror.3.6.nc.bz2 15a2542717d30f24feeb2ea9d5d73d754b30a3fc92bbf1b704b3ba23d2766d1b https://www.ngdc.noaa.gov/mgg/ocean_age/data/2008/grids/age_error/ageerror.3.6.nc.bz2

--- a/rockhound/seafloor.py
+++ b/rockhound/seafloor.py
@@ -1,0 +1,116 @@
+"""
+Load the seafloor age, spreading rate, and spreading symmetry grids by
+Müller et al. (2008).
+"""
+import os
+import bz2
+import shutil
+
+import xarray as xr
+
+from .registry import REGISTRY
+
+
+class Decompress:  # pylint: disable=too-few-public-methods
+    """
+    Decompress the bzip2 compressed grid after download.
+
+    This is a Pooch processor class that will be used with ``Pooch.fetch``.
+    """
+
+    def __call__(self, fname, action, pooch):
+        """
+        Decompress the given file.
+
+        The output file will be ``fname`` without the ``.bz2`` extension.
+
+        Parameters
+        ----------
+        fname : str
+            Full path of the compressed file in local storage.
+        action : str
+            Indicates what action was taken by :meth:`pooch.Pooch.fetch`. One of:
+
+            * ``"download"``: The file didn't exist locally and was downloaded
+            * ``"update"``: The local file was outdated and was re-download
+            * ``"fetch"``: The file exists and is updated so it wasn't downloaded
+
+        pooch : :class:`pooch.Pooch`
+            The instance of :class:`pooch.Pooch` that is calling this.
+
+        Returns
+        -------
+        fname : str
+            The full path to the decompressed file.
+
+        """
+        # Get rid of the .bz2
+        decomp = os.path.splitext(fname)[0]
+        if action in ("update", "download") or not os.path.exists(decomp):
+            with open(decomp, "w+b") as output:
+                with bz2.open(fname) as compressed:
+                    shutil.copyfileobj(compressed, output)
+        return decomp
+
+
+def fetch_seafloor_age(resolution="6min", load=True, **kwargs):
+    """
+    Fetch the age of the oceanic lithosphere global grid
+
+    Grids produced by [Muller2008]_.
+
+    Includes the age uncertainty grid as well. Both are available in 2 and 6 arc-minute
+    resolutions. The units for the ages are millions of years. The grids span longitudes
+    from 0 E to 360 E and latitudes from 90 N to -90 N and are grid-line registered.
+
+    If the files aren't already in your data directory, they will be downloaded
+    automatically.
+
+    Parameters
+    ----------
+    resolution : str
+        Which resolution grid to load. Must be ``"6min"`` or ``"2min"``.
+    load : bool
+        Wether to load the data into an :class:`xarray.Dataset` or just return the
+        path to the downloaded data. If False, will return a list with the paths to the
+        age and age uncertainty grids, respectively.
+    kwargs
+        Keyword arguments will be forwarded to the :func:`xarray.open_dataset` function
+        that loads the grid into memory.
+
+    Returns
+    -------
+    grid : :class:`xarray.Dataset` or str
+        The loaded grid or the file path to the downloaded data.
+
+    """
+    resolutions = ["6min", "2min"]
+    if resolution not in resolutions:
+        raise ValueError(
+            "Invalid seafloor age grid resolution '{}'. Must be one of {}.".format(
+                resolution, resolutions
+            )
+        )
+    fname_age = REGISTRY.fetch(
+        "age.3.{}.nc.bz2".format(resolution[0]), processor=Decompress()
+    )
+    fname_error = REGISTRY.fetch(
+        "ageerror.3.{}.nc.bz2".format(resolution[0]), processor=Decompress()
+    )
+    if not load:
+        return [fname_age, fname_error]
+    grid = xr.merge(
+        [
+            xr.open_dataset(fname_age, **kwargs).rename(z="age") / 100,
+            xr.open_dataset(fname_error, **kwargs).rename(z="uncertainty") / 100,
+        ]
+    )
+    # Add more metadata and fix some names
+    grid = grid.rename(x="longitude", y="latitude")
+    grid.attrs["title"] = "Age of oceanic lithosphere"
+    grid.attrs["doi"] = "10.1029/2007GC001743"
+    grid.age.attrs["long_name"] = "Age of oceanic lithosphere"
+    grid.age.attrs["units"] = "million_years"
+    grid.uncertainty.attrs["long_name"] = "Age uncertainty"
+    grid.uncertainty.attrs["units"] = "million_years"
+    return grid

--- a/rockhound/tests/test_seafloor.py
+++ b/rockhound/tests/test_seafloor.py
@@ -1,0 +1,34 @@
+"""
+Test the seafloor age grids.
+"""
+import pytest
+import numpy.testing as npt
+
+from .. import fetch_seafloor_age
+
+
+def test_seafloor_age_file_name_only():
+    "Make sure the correct file names are being returned"
+    names = fetch_seafloor_age(load=False)
+    assert len(names) == 2
+    assert names[0].endswith("age.3.6.nc")
+    assert names[1].endswith("ageerror.3.6.nc")
+
+
+def test_seafloor_age_invalid_resolution():
+    "Make sure an error is raised"
+    with pytest.raises(ValueError):
+        fetch_seafloor_age(resolution=6)
+    with pytest.raises(ValueError):
+        fetch_seafloor_age(resolution="bla")
+
+
+def test_seafloor_age():
+    "Sanity checks for the data"
+    grid = fetch_seafloor_age()
+    assert set(grid.data_vars) == {"age", "uncertainty"}
+    assert tuple(grid.dims) == ("latitude", "longitude")
+    assert grid.age.shape == (1801, 3601)
+    assert grid.uncertainty.shape == (1801, 3601)
+    npt.assert_allclose([grid.age.min(), grid.age.max()], [0, 280])
+    npt.assert_allclose([grid.uncertainty.min(), grid.uncertainty.max()], [0, 15])


### PR DESCRIPTION
Fetch and load the netCDF version of the age and uncertainty grids from
the NOAA NCEI website. Available in the 2 and 6 arc-minute resolutions.
Add metadata to the Dataset, like units, long names, and the Müller et
al (2008) paper DOI.

Fixes #9



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.