### PR TITLE
More metadata and faster plots Bedmap + ETOPO1

### DIFF
--- a/examples/bedmap2.py
+++ b/examples/bedmap2.py
@@ -15,13 +15,13 @@ import cmocean
 
 # Load the ice thickness grid
 bedmap = rh.fetch_bedmap2(datasets=["thickness"])
-# bedmap = bedmap.sel(x=slice(None, 0), y=slice(0, None))
 print(bedmap)
 
-plt.figure(figsize=(8, 9.5))
+plt.figure(figsize=(8, 7))
 ax = plt.subplot(111)
-pc = bedmap.thickness.plot.pcolormesh(ax=ax, cmap=cmocean.cm.ice, add_colorbar=False)
-plt.colorbar(pc, ax=ax, orientation="horizontal", pad=0.05, aspect=50, label="meters")
+pc = bedmap.thickness.plot.pcolormesh(
+    ax=ax, cmap=cmocean.cm.ice, cbar_kwargs=dict(pad=0.01, aspect=30)
+)
 ax.set_title("Bedmap2 Antarctica Ice Thickness")
 plt.tight_layout()
 plt.show()

--- a/examples/etopo1.py
+++ b/examples/etopo1.py
@@ -10,40 +10,23 @@ and make computations.
 """
 import rockhound as rh
 import matplotlib.pyplot as plt
-import cartopy.crs as ccrs
 import cmocean
 
-# Load both the ice surface and bedrock grids and merge them into a single Dataset
-grid = rh.fetch_etopo1(version="ice")
-grid = grid.merge(rh.fetch_etopo1(version="bedrock"))
-print("Entire dataset:\n\n", grid)
+# Load a version of the topography grid
+grid = rh.fetch_etopo1(version="bedrock")
+print(grid)
 
-# Select a subset of this large grid that corresponds to Iceland and Greenland
-iceland = grid.sel(latitude=slice(55, 80), longitude=slice(-50, -10))
-print("\nIceland subsection:\n\n", iceland)
+# Select a subset that corresponds to Africa to make plotting faster given the size of
+# the grid.
+africa = grid.sel(latitude=slice(-40, 45), longitude=slice(-20, 60))
 
-# Make maps of both versions using an Albers Equal Area projection
-proj = ccrs.AlbersEqualArea(central_longitude=-30, central_latitude=67.5)
-trans = ccrs.PlateCarree()
-
-# Setup some common arguments for the colorbar and pseudo-color plot
-cbar_kwargs = dict(pad=0, orientation="horizontal")
-pcolor_args = dict(
-    cmap=cmocean.cm.topo, add_colorbar=False, transform=ccrs.PlateCarree()
+# Plot the age grid.
+# We're not using a map projection to speed up the plotting but this NOT recommended.
+plt.figure(figsize=(9, 8))
+ax = plt.subplot(111)
+africa.bedrock.plot.pcolormesh(
+    cmap=cmocean.cm.topo, cbar_kwargs=dict(pad=0.01, aspect=30), ax=ax
 )
-
-# Draw the maps
-fig, axes = plt.subplots(1, 2, figsize=(9, 5), subplot_kw=dict(projection=proj))
-fig.suptitle("ETOPO1 Earth Relief of Iceland and Greenland")
-ax = axes[0]
-tmp = iceland.ice.plot.pcolormesh(ax=ax, **pcolor_args)
-plt.colorbar(tmp, ax=ax, **cbar_kwargs).set_label("[meters]")
-ax.gridlines()
-ax.set_title("Ice Surface")
-ax = axes[1]
-tmp = iceland.bedrock.plot.pcolormesh(ax=ax, **pcolor_args)
-plt.colorbar(tmp, ax=ax, **cbar_kwargs).set_label("[meters]")
-ax.gridlines()
-ax.set_title("Bedrock")
+ax.set_title("ETOPO1")
 plt.tight_layout()
 plt.show()

--- a/examples/seafloor_age.py
+++ b/examples/seafloor_age.py
@@ -20,8 +20,10 @@ print(grid)
 # Plot the age grid.
 # We're not using a map projection to speed up the plotting but this NOT recommended.
 plt.figure(figsize=(9, 5))
+ax = plt.subplot(111)
 grid.age.plot.pcolormesh(
-    cmap=cmocean.cm.thermal_r, cbar_kwargs=dict(pad=0.01, aspect=30)
+    cmap=cmocean.cm.thermal_r, cbar_kwargs=dict(pad=0.01, aspect=30), ax=ax
 )
+ax.set_title("Age of Oceanic Lithosphere")
 plt.tight_layout()
 plt.show()

--- a/rockhound/etopo1.py
+++ b/rockhound/etopo1.py
@@ -62,6 +62,8 @@ def fetch_etopo1(version, load=True, **kwargs):
     ice sheets). Each grid is in a separate gzipped netCDF file (grid-line registered
     version). The grids are loaded into :class:`xarray.Dataset` objects.
 
+    The vertical datum is sea level and the horizontal reference is the WGS84 ellipsoid.
+
     If the files aren't already in your data directory, they will be downloaded
     automatically (which may take a while). Each grid is approximately 380Mb.
 
@@ -97,8 +99,10 @@ def fetch_etopo1(version, load=True, **kwargs):
     # Add more metadata and fix some names
     names = {"ice": "Ice Surface", "bedrock": "Bedrock"}
     grid = grid.rename(z=version, x="longitude", y="latitude")
-    grid[version].attrs["long_name"] = "ETOPO1 {} relief [meters]".format(
-        names[version]
-    )
-    grid.attrs["title"] = grid[version].attrs["long_name"]
+    grid[version].attrs["long_name"] = "{} relief".format(names[version])
+    grid[version].attrs["units"] = "meters"
+    grid[version].attrs["vertical_datum"] = "sea level"
+    grid[version].attrs["datum"] = "WGS84"
+    grid.attrs["title"] = "ETOPO1 {} Relief".format(names[version])
+    grid.attrs["doi"] = "10.7289/V5C8276M"
     return grid

--- a/rockhound/tests/test_etopo1.py
+++ b/rockhound/tests/test_etopo1.py
@@ -24,9 +24,9 @@ def test_etopo1():
     "Sanity checks for the grid."
     grid = fetch_etopo1(version="ice")
     assert grid.ice.shape == (10801, 21601)
-    assert grid.attrs["title"] == "ETOPO1 Ice Surface relief [meters]"
+    assert grid.attrs["title"] == "ETOPO1 Ice Surface Relief"
     assert tuple(grid.dims) == ("latitude", "longitude")
     grid = fetch_etopo1(version="bedrock")
     assert grid.bedrock.shape == (10801, 21601)
-    assert grid.attrs["title"] == "ETOPO1 Bedrock relief [meters]"
+    assert grid.attrs["title"] == "ETOPO1 Bedrock Relief"
     assert tuple(grid.dims) == ("latitude", "longitude")


### PR DESCRIPTION
Include units and long names for coordinates and data variables for
Bedmap2 and ETOPO1. xarray puts these in the plots automatically, which
is nice.
Speed up the plots by not using projections. Not ideal but they look
better and run faster. Includes a notice not to do that in practice.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.