### PR TITLE
Use positional only arguments in all functions

### DIFF
--- a/rockhound/bedmap2.py
+++ b/rockhound/bedmap2.py
@@ -24,7 +24,7 @@ DATASETS = {
 }
 
 
-def fetch_bedmap2(datasets, load=True):
+def fetch_bedmap2(datasets, *, load=True):
     """
     Fetch the Bedmap2 datasets for Antarctica.
 

--- a/rockhound/etopo1.py
+++ b/rockhound/etopo1.py
@@ -52,7 +52,7 @@ class Decompress:  # pylint: disable=too-few-public-methods
         return decomp
 
 
-def fetch_etopo1(version, load=True, **kwargs):
+def fetch_etopo1(version, *, load=True, **kwargs):
     """
     Fetch the ETOPO1 global relief model.
 

--- a/rockhound/prem.py
+++ b/rockhound/prem.py
@@ -7,7 +7,7 @@ import numpy as np
 from .registry import REGISTRY
 
 
-def fetch_prem(load=True):
+def fetch_prem(*, load=True):
     r"""
     Fetch the Preliminary Reference Earth Model (PREM).
 

--- a/rockhound/seafloor.py
+++ b/rockhound/seafloor.py
@@ -53,7 +53,7 @@ class Decompress:  # pylint: disable=too-few-public-methods
         return decomp
 
 
-def fetch_seafloor_age(resolution="6min", load=True, **kwargs):
+def fetch_seafloor_age(*, resolution="6min", load=True, **kwargs):
     """
     Fetch the age of the oceanic lithosphere global grid
 


### PR DESCRIPTION
Python has syntax for only allowing keyword arguments to be specified by
users using the keyword. For example `fetch_prem(load=False)` would be
valid while `fetch_prem(False)` would not. This is good because it
prevents bugs down the line if we add or remove parameters.

We should adopt this for all our other projects.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.