### PR TITLE
Use pooch.os_cache to determine the data location

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -7,6 +7,8 @@ API Reference
 
 .. currentmodule:: rockhound
 
+Data Fetching and Loading
+-------------------------
 
 .. autosummary::
    :toctree: generated/
@@ -23,4 +25,5 @@ Utilities
 .. autosummary::
    :toctree: generated/
 
+    data_location
     test

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,6 +8,7 @@
     :caption: Documentation
 
     install.rst
+    registry.rst
     gallery/index.rst
     api/index.rst
     references.rst

--- a/doc/registry.rst
+++ b/doc/registry.rst
@@ -1,0 +1,18 @@
+.. _registry:
+
+Where are my data?
+==================
+
+The model and dataset files are downloaded automatically by :mod:`pooch` to the default
+cache location on your operating system. The location varies depending on your system
+and configuration. We provide the :func:`rockhound.data_location` function that will
+return the data storage location on your system.
+
+You can overwrite the local storage directory by setting the ``ROCKHOUND_DATA_DIR``
+environment variable to the desired path.
+
+All data fetching functions (see :ref:`api`) take an optional ``load=True`` argument.
+Setting it to ``False`` will tell the function to return the path to the data file
+instead of loading it into a Python variable.
+Use this to figure out where specific data files are and in case you wish to load the
+data yourself.

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -3,8 +3,4 @@
 Models and Datasets
 ===================
 
-The model and dataset files are downloaded automatically to a ``~/.rockhound/data``
-directory. You can configure this download directory by setting the
-``ROCKHOUND_DATA_DIR`` environment variable to the desired path.
-
 These are the currently avaialbe models/datasets:

--- a/rockhound/__init__.py
+++ b/rockhound/__init__.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring
 # Import functions/classes to make the public API
 from . import version
+from .registry import data_location
 from .etopo1 import fetch_etopo1
 from .prem import fetch_prem
 from .bedmap2 import fetch_bedmap2

--- a/rockhound/registry.py
+++ b/rockhound/registry.py
@@ -7,6 +7,25 @@ import pooch
 
 
 REGISTRY = pooch.create(
-    path=["~", ".rockhound", "data"], base_url="", env="ROCKHOUND_DATA_DIR"
+    path=pooch.os_cache("rockhound"), base_url="", env="ROCKHOUND_DATA_DIR"
 )
 REGISTRY.load_registry(os.path.join(os.path.dirname(__file__), "registry.txt"))
+
+
+def data_location():
+    r"""
+    The absolute path to the data storage location on disk.
+
+    This is where the data sets are saved on your computer. The data location is
+    dependent on the operating system. The folder locations are defined by the
+    ``appdirs``  package (see the
+    `appdirs documentation <https://github.com/ActiveState/appdirs>`__).
+    It can also be overwritten by the ``ROCKHOUND_DATA_DIR`` environment variable.
+
+    Returns
+    -------
+    path : str
+        The local data storage location.
+
+    """
+    return str(REGISTRY.abspath)

--- a/rockhound/tests/test_registry.py
+++ b/rockhound/tests/test_registry.py
@@ -10,4 +10,6 @@ def test_data_location():
     "Make sure the registry has the right last name"
     path = data_location()
     assert os.path.exists(path)
-    assert os.path.split(path)[-1] == "rockhound"
+    # This is the most we can check in a platform independent way without testing
+    # appdirs itself.
+    assert "rockhound" in path

--- a/rockhound/tests/test_registry.py
+++ b/rockhound/tests/test_registry.py
@@ -1,0 +1,13 @@
+"""
+Test the registry operation functions
+"""
+import os
+
+from ..registry import data_location
+
+
+def test_data_location():
+    "Make sure the registry has the right last name"
+    path = data_location()
+    assert os.path.exists(path)
+    assert os.path.split(path)[-1] == "rockhound"


### PR DESCRIPTION
The function finds the cache folder for each operating system. This is
more user friendly than setting the directory by hand (it plays nicely
with backups and cleaning programs). Can still be overwritten by the
environment variable. Provide a function that returns the cache location
for convenience to the user as well.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.