### PR TITLE
Use the new pooch.Decompress on ETOPO1 and seafloor

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
     - python=3.7
     - pip
-    - pooch>=0.4
+    - pooch>=0.5
     - xarray
     - pandas
     - rasterio

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pooch>=0.4
+pooch>=0.5
 xarray
 pandas
 rasterio

--- a/rockhound/etopo1.py
+++ b/rockhound/etopo1.py
@@ -1,12 +1,8 @@
 """
 Load the ETOPO1 Earth Relief dataset.
 """
-import os
-import gzip
-import shutil
-from pooch import Decompress
-
 import xarray as xr
+from pooch import Decompress
 
 from .registry import REGISTRY
 

--- a/rockhound/etopo1.py
+++ b/rockhound/etopo1.py
@@ -4,52 +4,11 @@ Load the ETOPO1 Earth Relief dataset.
 import os
 import gzip
 import shutil
+from pooch import Decompress
 
 import xarray as xr
 
 from .registry import REGISTRY
-
-
-class Decompress:  # pylint: disable=too-few-public-methods
-    """
-    Decompress the gzip compressed grid after download.
-
-    This is a Pooch processor class that will be used with ``Pooch.fetch``.
-    """
-
-    def __call__(self, fname, action, pooch):
-        """
-        Decompress the given file.
-
-        The output file will be ``fname`` without the ``.gz`` extension.
-
-        Parameters
-        ----------
-        fname : str
-            Full path of the compressed file in local storage.
-        action : str
-            Indicates what action was taken by :meth:`pooch.Pooch.fetch`. One of:
-
-            * ``"download"``: The file didn't exist locally and was downloaded
-            * ``"update"``: The local file was outdated and was re-download
-            * ``"fetch"``: The file exists and is updated so it wasn't downloaded
-
-        pooch : :class:`pooch.Pooch`
-            The instance of :class:`pooch.Pooch` that is calling this.
-
-        Returns
-        -------
-        fname : str
-            The full path to the decompressed file.
-
-        """
-        # Get rid of the .gz
-        decomp = os.path.splitext(fname)[0]
-        if action in ("update", "download") or not os.path.exists(decomp):
-            with open(decomp, "w+b") as output:
-                with gzip.open(fname) as compressed:
-                    shutil.copyfileobj(compressed, output)
-        return decomp
 
 
 def fetch_etopo1(version, *, load=True, **kwargs):

--- a/rockhound/seafloor.py
+++ b/rockhound/seafloor.py
@@ -5,52 +5,11 @@ Müller et al. (2008).
 import os
 import bz2
 import shutil
+from pooch import Decompress
 
 import xarray as xr
 
 from .registry import REGISTRY
-
-
-class Decompress:  # pylint: disable=too-few-public-methods
-    """
-    Decompress the bzip2 compressed grid after download.
-
-    This is a Pooch processor class that will be used with ``Pooch.fetch``.
-    """
-
-    def __call__(self, fname, action, pooch):
-        """
-        Decompress the given file.
-
-        The output file will be ``fname`` without the ``.bz2`` extension.
-
-        Parameters
-        ----------
-        fname : str
-            Full path of the compressed file in local storage.
-        action : str
-            Indicates what action was taken by :meth:`pooch.Pooch.fetch`. One of:
-
-            * ``"download"``: The file didn't exist locally and was downloaded
-            * ``"update"``: The local file was outdated and was re-download
-            * ``"fetch"``: The file exists and is updated so it wasn't downloaded
-
-        pooch : :class:`pooch.Pooch`
-            The instance of :class:`pooch.Pooch` that is calling this.
-
-        Returns
-        -------
-        fname : str
-            The full path to the decompressed file.
-
-        """
-        # Get rid of the .bz2
-        decomp = os.path.splitext(fname)[0]
-        if action in ("update", "download") or not os.path.exists(decomp):
-            with open(decomp, "w+b") as output:
-                with bz2.open(fname) as compressed:
-                    shutil.copyfileobj(compressed, output)
-        return decomp
 
 
 def fetch_seafloor_age(*, resolution="6min", load=True, **kwargs):

--- a/rockhound/seafloor.py
+++ b/rockhound/seafloor.py
@@ -2,12 +2,8 @@
 Load the seafloor age, spreading rate, and spreading symmetry grids by
 Müller et al. (2008).
 """
-import os
-import bz2
-import shutil
-from pooch import Decompress
-
 import xarray as xr
+from pooch import Decompress
 
 from .registry import REGISTRY
 

--- a/rockhound/tests/test_etopo1.py
+++ b/rockhound/tests/test_etopo1.py
@@ -15,9 +15,9 @@ def test_etopo1_invalid_version():
 def test_etopo1_file_name_only():
     "Only fetch the file name."
     name = fetch_etopo1(version="ice", load=False)
-    assert name.endswith("ETOPO1_Ice_g_gmt4.grd")
+    assert name.endswith("ETOPO1_Ice_g_gmt4.grd.gz.decomp")
     name = fetch_etopo1(version="bedrock", load=False)
-    assert name.endswith("ETOPO1_Bed_g_gmt4.grd")
+    assert name.endswith("ETOPO1_Bed_g_gmt4.grd.gz.decomp")
 
 
 def test_etopo1():

--- a/rockhound/tests/test_seafloor.py
+++ b/rockhound/tests/test_seafloor.py
@@ -11,8 +11,8 @@ def test_seafloor_age_file_name_only():
     "Make sure the correct file names are being returned"
     names = fetch_seafloor_age(load=False)
     assert len(names) == 2
-    assert names[0].endswith("age.3.6.nc")
-    assert names[1].endswith("ageerror.3.6.nc")
+    assert names[0].endswith("age.3.6.nc.bz2.decomp")
+    assert names[1].endswith("ageerror.3.6.nc.bz2.decomp")
 
 
 def test_seafloor_age_invalid_resolution():


### PR DESCRIPTION
Replace the `Decompress` classes with the new `pooch.Decompress`.

The minimum required version of Pooch was raised to `v0.5.0`.
Update tests for uncompressed filenames, they will be in the form of `{file}.decomp`.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
