### PR TITLE
Return a Dask array when loading Bedmap2

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -23,6 +23,7 @@ Dependencies
 * `xarray <https://xarray.pydata.org/>`__
 * `pandas <https://pandas.pydata.org>`__
 * `rasterio <https://rasterio.readthedocs.io>`__
+* `dask <https://dask.org/>`__
 
 Most of the examples in the :ref:`gallery` also use:
 

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
     - xarray
     - pandas
     - rasterio
+    - dask
     # Development requirements
     - matplotlib
     - cmocean

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pooch>=0.5
 xarray
 pandas
 rasterio
+dask

--- a/rockhound/bedmap2.py
+++ b/rockhound/bedmap2.py
@@ -55,8 +55,11 @@ def fetch_bedmap2(datasets, *, load=True, chunks=1000, **kwargs):
       relative to EIGEN-GL04C geoid (to convert back to WGS84, add this grid)
 
     .. warning ::
-        Loading a great number of datasets may require a fair amount of memory that
-        could crash your system. We recommend loading only the needed datasets.
+        Loading datasets into memory may require a fair amount of memory.
+        In order to prevent it the function loads the datasets as Dask arrays if
+        ``chunks`` is not ``None``.
+        Be careful when doing operations that loads the entire datasets into memory,
+        like plotting or performing some computations.
 
     .. warning ::
         Loading any dataset along with ``thickness_uncertainty_5km`` would modify the

--- a/rockhound/bedmap2.py
+++ b/rockhound/bedmap2.py
@@ -56,7 +56,7 @@ def fetch_bedmap2(datasets, *, load=True, chunks=1000, **kwargs):
 
     .. warning ::
         Loading datasets into memory may require a fair amount of memory.
-        In order to prevent it the function loads the datasets as Dask arrays if
+        In order to prevent this, the function loads the datasets as Dask arrays if
         ``chunks`` is not ``None``.
         Be careful when doing operations that loads the entire datasets into memory,
         like plotting or performing some computations.

--- a/rockhound/bedmap2.py
+++ b/rockhound/bedmap2.py
@@ -24,7 +24,7 @@ DATASETS = {
 }
 
 
-def fetch_bedmap2(datasets, *, load=True):
+def fetch_bedmap2(datasets, *, load=True, chunks=100, **kwargs):
     """
     Fetch the Bedmap2 datasets for Antarctica.
 
@@ -70,6 +70,12 @@ def fetch_bedmap2(datasets, *, load=True):
         Wether to load the data into an :class:`xarray.Dataset` or just return the
         path to the downloaded data tiff files. If False, will return a list with the
         paths to the files corresponding to *datasets*.
+    chunks : int, tuple or dict
+        Chunk sizes along each dimension. This argument is passed to the
+        :func:`xarray.open_rasterio` function in order to return a Dask array.
+        This helps to read the dataset without loading it entirely into memory.
+    kwargs : dict
+        Extra parameters passed to the :func:`xarray.open_rasterio` function.
 
     Returns
     -------
@@ -88,7 +94,7 @@ def fetch_bedmap2(datasets, *, load=True):
         return [get_fname(dataset, fnames) for dataset in datasets]
     arrays = []
     for dataset in datasets:
-        array = xr.open_rasterio(get_fname(dataset, fnames))
+        array = xr.open_rasterio(get_fname(dataset, fnames), chunks=chunks, **kwargs)
         # Replace no data values with nans
         array = array.where(array != array.nodatavals)
         # Remove "band" dimension and coordinate

--- a/rockhound/bedmap2.py
+++ b/rockhound/bedmap2.py
@@ -72,7 +72,8 @@ def fetch_bedmap2(datasets, *, load=True, chunks=100, **kwargs):
         paths to the files corresponding to *datasets*.
     chunks : int, tuple or dict
         Chunk sizes along each dimension. This argument is passed to the
-        :func:`xarray.open_rasterio` function in order to return a Dask array.
+        :func:`xarray.open_rasterio` function in order to obtain Dask arrays inside the
+        returned :class:`xarray.Dataset`.
         This helps to read the dataset without loading it entirely into memory.
     kwargs : dict
         Extra parameters passed to the :func:`xarray.open_rasterio` function.

--- a/rockhound/bedmap2.py
+++ b/rockhound/bedmap2.py
@@ -76,7 +76,7 @@ def fetch_bedmap2(datasets, *, load=True, chunks=100, **kwargs):
         `Dask arrays <https://docs.dask.org/en/latest/array.html>`_ inside the
         returned :class:`xarray.Dataset`.
         This helps to read the dataset without loading it entirely into memory.
-    kwargs : dict
+    **kwargs
         Extra parameters passed to the :func:`xarray.open_rasterio` function.
 
     Returns

--- a/rockhound/bedmap2.py
+++ b/rockhound/bedmap2.py
@@ -72,7 +72,8 @@ def fetch_bedmap2(datasets, *, load=True, chunks=100, **kwargs):
         paths to the files corresponding to *datasets*.
     chunks : int, tuple or dict
         Chunk sizes along each dimension. This argument is passed to the
-        :func:`xarray.open_rasterio` function in order to obtain Dask arrays inside the
+        :func:`xarray.open_rasterio` function in order to obtain
+        `Dask arrays <https://docs.dask.org/en/latest/array.html>`_ inside the
         returned :class:`xarray.Dataset`.
         This helps to read the dataset without loading it entirely into memory.
     kwargs : dict

--- a/rockhound/bedmap2.py
+++ b/rockhound/bedmap2.py
@@ -24,7 +24,7 @@ DATASETS = {
 }
 
 
-def fetch_bedmap2(datasets, *, load=True, chunks=100, **kwargs):
+def fetch_bedmap2(datasets, *, load=True, chunks=1000, **kwargs):
     """
     Fetch the Bedmap2 datasets for Antarctica.
 


### PR DESCRIPTION
Add `chunks` argument to `fetch_bedmap2` in order to create a Dask array instead of loading the entire dataset into memory.
Also, add keyword arguments to be passed to `xarray.open_rasterio` function in case any other parameter of the array creation wants to be changed.

Fixes #44 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
