### PR TITLE
Disable pylint warning on __init__.py

### DIFF
--- a/rockhound/__init__.py
+++ b/rockhound/__init__.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring
+# pylint: disable=missing-docstring,import-outside-toplevel
 # Import functions/classes to make the public API
 from . import version
 from .registry import data_location


### PR DESCRIPTION
Disable import-outside-toplevel pylint warning on rockhound/__init__.py.
The warning was raised because pylint was being imported outside toplevel.
Inspired on fatiando/harmonica#105.


<!-- Please describe changes proposed and WHY you made them. If unsure, open an issue first to discuss the idea. -->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.