### PR TITLE
Wrap docstrings to 79 chars and check with flake8

### DIFF
--- a/examples/bedmap2.py
+++ b/examples/bedmap2.py
@@ -2,12 +2,13 @@
 Bedmap2
 =======
 
-Bedmap2 is a suite of gridded products describing surface elevation, ice-thickness, the
-sea floor and subglacial bed elevation of the Antarctic south of 60°S [BEDMAP2]_.
-Each dataset is projected in Antarctic Polar Stereographic projection, latitude of true
-scale -71 degrees south, datum WGS84. All heights are in metres relative to sea level as
-defined by the g104c geoid. The datasets are downloaded as ``tiff`` files and loaded
-into a :class:`xarray.Dataset` object.
+Bedmap2 is a suite of gridded products describing surface elevation,
+ice-thickness, the sea floor and subglacial bed elevation of the Antarctic
+south of 60°S [BEDMAP2]_. Each dataset is projected in Antarctic Polar
+Stereographic projection, latitude of true scale -71 degrees south, datum
+WGS84. All heights are in metres relative to sea level as defined by the g104c
+geoid. The datasets are downloaded as ``tiff`` files and loaded into
+a :class:`xarray.Dataset` object.
 """
 import rockhound as rh
 import matplotlib.pyplot as plt

--- a/examples/etopo1.py
+++ b/examples/etopo1.py
@@ -2,11 +2,11 @@
 ETOPO1 Earth Relief
 ===================
 
-ETOPO1 is a 1 arc-minute global relief model of Earth's surface that integrates land
-topography and ocean bathymetry [AmanteEakins2009]_. It's available in two versions:
-"Ice Surface" (top of Antarctic and Greenland ice sheets) and "Bedrock" (base of the ice
-sheets). The grids are loaded into :class:`xarray.Dataset` which can be used to plot
-and make computations.
+ETOPO1 is a 1 arc-minute global relief model of Earth's surface that integrates
+land topography and ocean bathymetry [AmanteEakins2009]_. It's available in two
+versions: "Ice Surface" (top of Antarctic and Greenland ice sheets) and
+"Bedrock" (base of the ice sheets). The grids are loaded into
+:class:`xarray.Dataset` which can be used to plot and make computations.
 """
 import rockhound as rh
 import matplotlib.pyplot as plt
@@ -16,12 +16,13 @@ import cmocean
 grid = rh.fetch_etopo1(version="bedrock")
 print(grid)
 
-# Select a subset that corresponds to Africa to make plotting faster given the size of
-# the grid.
+# Select a subset that corresponds to Africa to make plotting faster given the
+# size of the grid.
 africa = grid.sel(latitude=slice(-40, 45), longitude=slice(-20, 60))
 
 # Plot the age grid.
-# We're not using a map projection to speed up the plotting but this NOT recommended.
+# We're not using a map projection to speed up the plotting but this NOT
+# recommended.
 plt.figure(figsize=(9, 8))
 ax = plt.subplot(111)
 africa.bedrock.plot.pcolormesh(

--- a/examples/prem.py
+++ b/examples/prem.py
@@ -2,11 +2,13 @@ r"""
 PREM: Preliminary Reference Earth Model
 =======================================
 
-The Preliminary reference Earth model (PREM) [Dziewonsky1981]_ is a one-dimensional
-model representing the average Earth properties as a function of planetary radius.  The
-model includes the depth, density, seismic velocities, attenuation (Q) and anisotropic
-parameter (:math:`\eta`) on the boundaries of several Earth layers.  The data is loaded
-into :class:`pandas.DataFrame` objects, which can be used to plot and make computations.
+The Preliminary reference Earth model (PREM) [Dziewonsky1981]_ is
+a one-dimensional model representing the average Earth properties as a function
+of planetary radius.  The model includes the depth, density, seismic
+velocities, attenuation (Q) and anisotropic parameter (:math:`\eta`) on the
+boundaries of several Earth layers. The data is loaded into
+:class:`pandas.DataFrame` objects, which can be used to plot and make
+computations.
 """
 import rockhound as rh
 import matplotlib.pyplot as plt

--- a/examples/seafloor_age.py
+++ b/examples/seafloor_age.py
@@ -3,10 +3,12 @@ Age of the Oceanic Lithosphere
 ==============================
 
 Global grids of the age of the oceanic lithosphere produced by [Muller2008]_.
-Available in 2 and 6 arc-minute resolutions and include grids of the age uncertainty.
+Available in 2 and 6 arc-minute resolutions and include grids of the age
+uncertainty.
 More information at the
 `NOAA NCEI <https://www.ngdc.noaa.gov/mgg/ocean_age/ocean_age_2008.html>`__ and
-`EarthByte <http://www.earthbyte.org/age-spreading-rates-and-spreading-asymmetry-of-the-worlds-ocean-crust/>`__
+`EarthByte
+<http://www.earthbyte.org/age-spreading-rates-and-spreading-asymmetry-of-the-worlds-ocean-crust/>`__
 websites.
 """
 import rockhound as rh
@@ -18,7 +20,8 @@ grid = rh.fetch_seafloor_age()
 print(grid)
 
 # Plot the age grid.
-# We're not using a map projection to speed up the plotting but this NOT recommended.
+# We're not using a map projection to speed up the plotting but this NOT
+# recommended.
 plt.figure(figsize=(9, 5))
 ax = plt.subplot(111)
 grid.age.plot.pcolormesh(

--- a/examples/slab2.py
+++ b/examples/slab2.py
@@ -2,10 +2,11 @@
 Slab2 - A Comprehensive Subduction Zone Geometry Model
 ======================================================
 
-Slab2 is a three-dimensional compilation of global subduction geometries, separated
-into regional models for each major subduction zone.
+Slab2 is a three-dimensional compilation of global subduction geometries,
+separated into regional models for each major subduction zone.
 More information at the
-`USGS <https://www.sciencebase.gov/catalog/item/5aa1b00ee4b0b1c392e86467>`__ website.
+`USGS <https://www.sciencebase.gov/catalog/item/5aa1b00ee4b0b1c392e86467>`__
+website.
 """
 
 import rockhound as rh

--- a/rockhound/bedmap2.py
+++ b/rockhound/bedmap2.py
@@ -29,50 +29,53 @@ def fetch_bedmap2(datasets, *, load=True, chunks=1000, **kwargs):
     Fetch the Bedmap2 datasets for Antarctica.
 
     Bedmap2 is a suite of gridded products describing surface elevation,
-    ice-thickness, the sea floor and subglacial bed elevation of the Antarctic south
-    of 60°S [BEDMAP2]_.
+    ice-thickness, the sea floor and subglacial bed elevation of the Antarctic
+    south of 60°S [BEDMAP2]_.
     The datasets are downloaded as ``tiff`` files and loaded into a
     :class:`xarray.Dataset` object.
 
-    Each dataset is projected in Antarctic Polar Stereographic projection, latitude of
-    true scale -71 degrees south, datum WGS84. All heights are in metres relative to
-    sea level as defined by the g104c geoid.
+    Each dataset is projected in Antarctic Polar Stereographic projection,
+    latitude of true scale -71 degrees south, datum WGS84. All heights are in
+    metres relative to sea level as defined by the g104c geoid.
 
     The available datasets are:
 
     - ``bed``: bedrock height
     - ``surface``: ice surface height
     - ``thickness``: ice thickness
-    - ``icemask_grounded_and_shelves``: mask showing the grounding line and the extent
-      of the floating ice shelves
+    - ``icemask_grounded_and_shelves``: mask showing the grounding line and the
+      extent of the floating ice shelves
     - ``rockmask``: mask showing rock outcrops
-    - ``lakemask_vostok``: mask showing the extent of the lake cavity of Lake Vostok
+    - ``lakemask_vostok``: mask showing the extent of the lake cavity of Lake
+      Vostok
     - ``grounded_bed_uncertainty``: ice bed uncertainty grid
     - ``thickness_uncertainty_5km``: ice thickness uncertainty grid
-    - ``coverage``: binary grid showing the distribution of ice thickness data used
-      in the grid of ice thickness
-    - ``geoid``: values to convert from heights relative to WGS84 datum to heights
-      relative to EIGEN-GL04C geoid (to convert back to WGS84, add this grid)
+    - ``coverage``: binary grid showing the distribution of ice thickness data
+      used in the grid of ice thickness
+    - ``geoid``: values to convert from heights relative to WGS84 datum to
+      heights relative to EIGEN-GL04C geoid (to convert back to WGS84, add this
+      grid)
 
     .. warning ::
         Loading datasets into memory may require a fair amount of memory.
-        In order to prevent this, the function loads the datasets as Dask arrays if
-        ``chunks`` is not ``None``.
-        Be careful when doing operations that loads the entire datasets into memory,
-        like plotting or performing some computations.
+        In order to prevent this, the function loads the datasets as Dask
+        arrays if ``chunks`` is not ``None``.
+        Be careful when doing operations that loads the entire datasets into
+        memory, like plotting or performing some computations.
 
     .. warning ::
-        Loading any dataset along with ``thickness_uncertainty_5km`` would modify the
-        shape of the ``grid`` because it's defined on a different set of points.
+        Loading any dataset along with ``thickness_uncertainty_5km`` would
+        modify the shape of the ``grid`` because it's defined on a different
+        set of points.
 
     Parameters
     ----------
     datasets : list or str
         Names of the datasets that will be loaded from the Bedmap2 model.
     load : bool
-        Wether to load the data into an :class:`xarray.Dataset` or just return the
-        path to the downloaded data tiff files. If False, will return a list with the
-        paths to the files corresponding to *datasets*.
+        Wether to load the data into an :class:`xarray.Dataset` or just return
+        the path to the downloaded data tiff files. If False, will return
+        a list with the paths to the files corresponding to *datasets*.
     chunks : int, tuple or dict
         Chunk sizes along each dimension. This argument is passed to the
         :func:`xarray.open_rasterio` function in order to obtain

--- a/rockhound/etopo1.py
+++ b/rockhound/etopo1.py
@@ -11,13 +11,15 @@ def fetch_etopo1(version, *, load=True, **kwargs):
     """
     Fetch the ETOPO1 global relief model.
 
-    ETOPO1 is a 1 arc-minute global relief model of Earth's surface that integrates land
-    topography and ocean bathymetry [AmanteEakins2009]_. It's available in two versions:
-    "Ice Surface" (top of Antarctic and Greenland ice sheets) and "Bedrock" (base of the
-    ice sheets). Each grid is in a separate gzipped netCDF file (grid-line registered
-    version). The grids are loaded into :class:`xarray.Dataset` objects.
+    ETOPO1 is a 1 arc-minute global relief model of Earth's surface that
+    integrates land topography and ocean bathymetry [AmanteEakins2009]_. It's
+    available in two versions: "Ice Surface" (top of Antarctic and Greenland
+    ice sheets) and "Bedrock" (base of the ice sheets). Each grid is in
+    a separate gzipped netCDF file (grid-line registered version). The grids
+    are loaded into :class:`xarray.Dataset` objects.
 
-    The vertical datum is sea level and the horizontal reference is the WGS84 ellipsoid.
+    The vertical datum is sea level and the horizontal reference is the WGS84
+    ellipsoid.
 
     If the files aren't already in your data directory, they will be downloaded
     automatically (which may take a while). Each grid is approximately 380Mb.
@@ -25,14 +27,14 @@ def fetch_etopo1(version, *, load=True, **kwargs):
     Parameters
     ----------
     version : str
-        Which version of the dataset to load. Can be ``"ice"`` for the ice surface
-        version, ``'bedrock'`` for the bedrock version.
+        Which version of the dataset to load. Can be ``"ice"`` for the ice
+        surface version, ``'bedrock'`` for the bedrock version.
     load : bool
-        Wether to load the data into an :class:`xarray.Dataset` or just return the
-        path to the downloaded data.
+        Wether to load the data into an :class:`xarray.Dataset` or just return
+        the path to the downloaded data.
     kwargs
-        Keyword arguments will be forwarded to the :func:`xarray.open_dataset` function
-        that loads the grid into memory.
+        Keyword arguments will be forwarded to the :func:`xarray.open_dataset`
+        function that loads the grid into memory.
 
     Returns
     -------

--- a/rockhound/prem.py
+++ b/rockhound/prem.py
@@ -11,12 +11,14 @@ def fetch_prem(*, load=True):
     r"""
     Fetch the Preliminary Reference Earth Model (PREM).
 
-    The Preliminary reference Earth model [Dziewonsky1981]_ is a one-dimensional model
-    representing the average Earth properties as a function of planetary radius.
-    The model includes the depth, density, seismic velocities, attenuation (Q) and
-    anisotropic parameter (:math:`\eta`) on the boundaries of several Earth layers.
-    It's available through IRIS Data Services Products [IRIS2011]_ in a csv file
-    (comma-separated values). The data is loaded into :class:`pandas.DataFrame` objects.
+    The Preliminary reference Earth model [Dziewonsky1981]_ is
+    a one-dimensional model representing the average Earth properties as
+    a function of planetary radius. The model includes the depth, density,
+    seismic velocities, attenuation (Q) and anisotropic parameter
+    (:math:`\eta`) on the boundaries of several Earth layers. It's available
+    through IRIS Data Services Products [IRIS2011]_ in a csv file
+    (comma-separated values). The data is loaded into :class:`pandas.DataFrame`
+    objects.
 
     If the file isn't already in your data directory, it will be downloaded
     automatically.
@@ -24,8 +26,8 @@ def fetch_prem(*, load=True):
     Parameters
     ----------
     load : bool
-        Wether to load the data into a :class:`pandas.DataFrame` or just return the
-        path to the downloaded data.
+        Wether to load the data into a :class:`pandas.DataFrame` or just return
+        the path to the downloaded data.
 
     Returns
     -------

--- a/rockhound/registry.py
+++ b/rockhound/registry.py
@@ -16,11 +16,12 @@ def data_location():
     r"""
     The absolute path to the data storage location on disk.
 
-    This is where the data sets are saved on your computer. The data location is
-    dependent on the operating system. The folder locations are defined by the
-    ``appdirs``  package (see the
+    This is where the data sets are saved on your computer. The data location
+    is dependent on the operating system. The folder locations are defined by
+    the ``appdirs``  package (see the
     `appdirs documentation <https://github.com/ActiveState/appdirs>`__).
-    It can also be overwritten by the ``ROCKHOUND_DATA_DIR`` environment variable.
+    It can also be overwritten by the ``ROCKHOUND_DATA_DIR`` environment
+    variable.
 
     Returns
     -------

--- a/rockhound/seafloor.py
+++ b/rockhound/seafloor.py
@@ -14,9 +14,10 @@ def fetch_seafloor_age(*, resolution="6min", load=True, **kwargs):
 
     Grids produced by [Muller2008]_.
 
-    Includes the age uncertainty grid as well. Both are available in 2 and 6 arc-minute
-    resolutions. The units for the ages are millions of years. The grids span longitudes
-    from 0 E to 360 E and latitudes from 90 N to -90 N and are grid-line registered.
+    Includes the age uncertainty grid as well. Both are available in 2 and
+    6 arc-minute resolutions. The units for the ages are millions of years. The
+    grids span longitudes from 0 E to 360 E and latitudes from 90 N to -90
+    N and are grid-line registered.
 
     If the files aren't already in your data directory, they will be downloaded
     automatically.
@@ -26,12 +27,12 @@ def fetch_seafloor_age(*, resolution="6min", load=True, **kwargs):
     resolution : str
         Which resolution grid to load. Must be ``"6min"`` or ``"2min"``.
     load : bool
-        Wether to load the data into an :class:`xarray.Dataset` or just return the
-        path to the downloaded data. If False, will return a list with the paths to the
-        age and age uncertainty grids, respectively.
+        Wether to load the data into an :class:`xarray.Dataset` or just return
+        the path to the downloaded data. If False, will return a list with the
+        paths to the age and age uncertainty grids, respectively.
     kwargs
-        Keyword arguments will be forwarded to the :func:`xarray.open_dataset` function
-        that loads the grid into memory.
+        Keyword arguments will be forwarded to the :func:`xarray.open_dataset`
+        function that loads the grid into memory.
 
     Returns
     -------

--- a/rockhound/slab2.py
+++ b/rockhound/slab2.py
@@ -48,13 +48,13 @@ def fetch_slab2(zone, *, load=True):
     """
     Load the Slab2 model for a given subduction zone.
 
-    Slab2 is a three-dimensional compilation of global subduction geometries (depth,
-    dip, strike and thickness), separated into regional models for each major
-    subduction zone.
-    Each model is based on a probabilistic non-linear fit to data from a combined
-    catalog consisting of several independent data sets - historic earthquake
-    catalogs, CMT solutions, active seismic profiles, global plate boundaries,
-    bathymetry and sediment thickness information [SLAB2]_.
+    Slab2 is a three-dimensional compilation of global subduction geometries
+    (depth, dip, strike and thickness), separated into regional models for each
+    major subduction zone.
+    Each model is based on a probabilistic non-linear fit to data from
+    a combined catalog consisting of several independent data sets - historic
+    earthquake catalogs, CMT solutions, active seismic profiles, global plate
+    boundaries, bathymetry and sediment thickness information [SLAB2]_.
 
     Parameters
     ----------
@@ -91,12 +91,12 @@ def fetch_slab2(zone, *, load=True):
         - ``vanuatu``: Vanuatu
 
     load : bool
-        Whether to load the data into an :class:`xarray.Dataset` or just return the
-        path to the downloaded data. If False, will return a list with the paths to the
-        subduction grids, respectively.
+        Whether to load the data into an :class:`xarray.Dataset` or just return
+        the path to the downloaded data. If False, will return a list with the
+        paths to the subduction grids, respectively.
     kwargs
-        Keyword arguments will be forwarded to the :func:`xarray.open_dataset` function
-        that loads the grid into memory.
+        Keyword arguments will be forwarded to the :func:`xarray.open_dataset`
+        function that loads the grid into memory.
 
     Returns
     -------

--- a/rockhound/tests/test_registry.py
+++ b/rockhound/tests/test_registry.py
@@ -10,6 +10,6 @@ def test_data_location():
     "Make sure the registry has the right last name"
     path = data_location()
     assert os.path.exists(path)
-    # This is the most we can check in a platform independent way without testing
-    # appdirs itself.
+    # This is the most we can check in a platform independent way without
+    # testing appdirs itself.
     assert "rockhound" in path

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,4 @@ tag_prefix = ''
 [flake8]
 ignore = E203, E266, E501, W503, F401, E741
 max-line-length = 88
+max-doc-length = 79


### PR DESCRIPTION
Wrap all docstrings to 79 characters of API functions. Set
`max-doc-length=79` characters to make flake8 check if any docstring
exceeds it.

Fixes #58 


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
