### PR TITLE
Add changelog entry for v0.2.1

### DIFF
--- a/CITATION.rst
+++ b/CITATION.rst
@@ -7,5 +7,5 @@ that goes into building and maintaining this project.
 If you used RockHound in your research, please consider citing it:
 
    Uieda, L., and Soler, S.R. (2019). Rockhound: Download geophysical models/datasets
-   and load them in Python (Version 0.1.0). Zenodo. https://doi.org/10.5281/zenodo.3086002
+   and load them in Python (Version 0.2.0). Zenodo. https://doi.org/10.5281/zenodo.3627166
 

--- a/CITATION.rst
+++ b/CITATION.rst
@@ -6,6 +6,7 @@ that goes into building and maintaining this project.
 
 If you used RockHound in your research, please consider citing it:
 
-   Uieda, L., and Soler, S.R. (2019). Rockhound: Download geophysical models/datasets
-   and load them in Python (Version 0.2.0). Zenodo. https://doi.org/10.5281/zenodo.3627166
+   Uieda, L., and Soler, S.R., Pesce, A. (2020). Rockhound: Download geophysical
+   models/datasets and load them in Python (Version 0.2.0). Zenodo.
+   https://doi.org/10.5281/zenodo.3627166
 

--- a/README.rst
+++ b/README.rst
@@ -42,9 +42,9 @@ Part of the `Fatiando a Terra <https://www.fatiando.org>`__ project
 .. image:: https://img.shields.io/gitter/room/fatiando/fatiando.svg?style=flat-square
     :alt: Chat room on Gitter
     :target: https://gitter.im/fatiando/fatiando
-.. image:: https://img.shields.io/badge/doi-10.5281%2Fzenodo.3086002-blue.svg?style=flat-square
+.. image:: https://img.shields.io/badge/doi-10.5281%2Fzenodo.3627166-blue.svg?style=flat-square
     :alt: Digital Object Identifier for the Zenodo archive
-    :target: https://doi.org/10.5281/zenodo.3086002
+    :target: https://doi.org/10.5281/zenodo.3627166
 
 
 .. placeholder-for-doc-index

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -3,6 +3,19 @@
 Changelog
 =========
 
+Version 0.2.1
+-------------
+
+*Released on: 2020/01/27*
+
+
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3627166.svg
+   :target: https://doi.org/10.5281/zenodo.3627166
+
+This is minor release which only updates the citation information to the new
+DOI. No DOI was issued for this release since there are no code or
+documentation changes.
+
 Version 0.2.0
 -------------
 


### PR DESCRIPTION
I forgot to update the new DOI for version v0.2.0 on the Zenodo badge in `README.rst` and on the instructions in `CITATION.rst`. These new release just updates the DOI for v0.2.0. It does not issue a new DOI because there are no changes on code nor documentation.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
