### PR TITLE
Explicitly set PR trigger for all branches on Azure

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -9,6 +9,12 @@ trigger:
     - master
     - refs/tags/*
 
+# Make sure triggers are set for PRs to any branch.
+pr:
+  branches:
+    include:
+    - '*'
+
 
 jobs:
 


### PR DESCRIPTION
For some reason, Azure Pipelines CI wasn't starting up PRs, only on
master and tags. Explicitly setting a trigger for PRs against any branch
seems to work.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
