### PR TITLE
Restore updated issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,51 @@
+---
+name: Bug report
+about: Report a problem/bug to help us improve
+
+---
+
+**Description of the problem**
+
+<!--
+Please be as detailed as you can when describing an issue. The more information
+we have, the easier it will be for us to track this down.
+-->
+
+
+
+**Full code that generated the error**
+
+<!--
+Include any data files or inputs required to run the code. It really helps if
+we can run the code on our own machines.
+-->
+
+```python
+PASTE YOUR CODE HERE
+```
+
+
+**Full error message**
+
+```
+PASTE ERROR MESSAGE HERE
+```
+
+
+
+**System information**
+
+* Operating system:
+* Python installation (Anaconda, system, ETS):
+* Version of Python:
+* Version of this package:
+* If using conda, paste the output of `conda list` below:
+
+<details>
+<summary>output of conda list</summary>
+<pre>
+
+PASTE OUTPUT OF CONDA LIST HERE
+
+</pre>
+</details>

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Request the addition of a new feature/functionality
+
+---
+
+**Description of the desired feature**
+
+<!--
+Please be as detailed as you can in your description. If possible, include an
+example of how you would like to use this feature (even better if it's a code
+example).
+-->
+
+
+
+**Are you willing to help implement and maintain this feature?** Yes/No
+
+<!--
+Every feature we add is code that we will have to maintain and keep updated.
+This takes a lot of effort. If you are willing to be involved in the project
+and help maintain your feature, it will make it easier for us to accept it.
+-->


### PR DESCRIPTION
Restore `ISSUE_TEMPLATE/bug_report.md`
`ISSUE_TEMPLATE/feature_request.md` with their updated versions from
`fatiando/.github`. When leaving only the
`ISSUE_TEMPLATE/dataset_request.md`, all other issues templates in
`fatiando/.github` are not shown.

**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
