### PR TITLE
Increase gallery thumbnail size and style tweaks

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -105,3 +105,23 @@ h1 {
         margin-top: 20px;
     }
 }
+
+/* sphinx-gallery configuration */
+.sphx-glr-thumbcontainer {
+    min-height: 370px !important;
+    margin: 5px !important;
+}
+
+.sphx-glr-thumbcontainer .figure {
+    width: 250px !important;
+}
+
+.sphx-glr-thumbcontainer img {
+    max-height: 250px !important;
+    max-width: 100% !important;
+}
+
+.sphx-glr-thumbcontainer a.internal {
+    padding: 280px 10px 0 !important;
+    text-align: center;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -61,6 +61,8 @@ sphinx_gallery_conf = {
     'doc_module': 'rockhound',
     # Insert links to documentation of objects in the examples
     'reference_url': {'rockhound': None},
+    # Increase the size of generated thumbnails
+    'thumbnail_size': (500, 500),
 }
 
 # Always show the source code that generates a plot


### PR DESCRIPTION
The thumbnails are a bit small and hard to see. Some of the titles are
also a bit long and end up out of the bounding box. Increase the sizes
of the figures generated (in doc/conf.py) and tweak the spacing and
bounding boxes in the sphinx-gallery CSS.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] If adding new example, please build the docs with `make -C doc gallery` and push the changes made on `doc/gallery`. Continuous Integration services build and deploy the docs, but they won't run the examples.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.


**Reminders for Maintainers**:

- [ ] Maintainers **must** run all tests locally before the PR is merged. CIs run only minimal tests and styling checks.
