### PR TITLE
Add Release Drafter to generate the changelog

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,7 @@
 # Configuration for the Release Drafter workflow
 name-template: 'v$NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
+change-template: '* $TITLE ([#$NUMBER]($URL) by [@$AUTHOR](https://github.com/$AUTHOR))'
 categories:
   - title: 'New functions/classes'
     label: 'feature'
@@ -16,13 +17,12 @@ categories:
     label: 'maintenance'
 exclude-labels:
   - 'skip-changelog'
-change-template: '* $TITLE ([#$NUMBER]($URL) by [@$AUTHOR](https://github.com/$AUTHOR))'
 template: |
   [![DOI](https://zenodo.org/badge/DOI/PASTE_DOI_HERE.svg)](https://doi.org/PASTE_DOI_HERE)
 
   ## Highlights
 
-  *
+  * DELETE IF THERE ARE NO HIGHLIGHTS
 
   $CHANGES
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,31 @@
+# Configuration for the Release Drafter workflow
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: 'New functions/classes'
+    label: 'feature'
+  - title: 'Enhancements'
+    label: 'enhancement'
+  - title: 'Bug Fixes'
+    label: 'bug'
+  - title: 'Deprecations'
+    label: 'deprecation'
+  - title: 'Documentation'
+    label: 'documentation'
+  - title: 'Maintenance'
+    label: 'maintenance'
+exclude-labels:
+  - 'skip-changelog'
+change-template: '* $TITLE ([#$NUMBER]($URL) by [@$AUTHOR](https://github.com/$AUTHOR))'
+template: |
+  [![DOI](https://zenodo.org/badge/DOI/PASTE_DOI_HERE.svg)](https://doi.org/PASTE_DOI_HERE)
+
+  ## Highlights
+
+  *
+
+  $CHANGES
+
+  ## This release contains contributions from:
+
+  $CONTRIBUTORS

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,6 +9,7 @@ on:
     # Only run the release drafter on the master branch after a PR is merged
     branches:
       - master
+      - release-drafter
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,4 +21,4 @@ jobs:
           # config name to use, relative to .github/
           config-name: release-drafter.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,6 @@ on:
     # Only run the release drafter on the master branch after a PR is merged
     branches:
       - master
-      - release-drafter
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,7 +6,7 @@ name: Release Drafter
 
 on:
   push:
-    # branches to consider in the event; optional, defaults to all
+    # Only run the release drafter on the master branch after a PR is merged
     branches:
       - master
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+# Add PR titles, numbers, and contributors to a draft release as they are
+# merged. This is the workflow configuration. For the configuration of the
+# draft release (labels to use, headings, etc), see .github/release-drafter.yml
+# https://github.com/release-drafter/release-drafter
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          # config name to use, relative to .github/
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }


### PR DESCRIPTION
This Github Action automatically generates a changelog based on pull
requests merged. The `.github/workflows/release-drafter.yml` sets up the
workflow and `.github/release-drafter.yml` configures the generated
changelog. A caveat is that the names of contributors is given only as
their Github handle and not the full names (which we were using before).
This is a minor sacrifice that I'm willing to make.

Fixes #86 

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] If adding new example, please build the docs with `make -C doc gallery` and push the changes made on `doc/gallery`. Continuous Integration services build and deploy the docs, but they won't run the examples.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.


**Reminders for Maintainers**:

- [ ] Maintainers **must** run all tests locally before the PR is merged. CIs run only minimal tests and styling checks.
