### PR TITLE
Fix documentation deploy from TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,14 +81,14 @@ deploy:
     # Push the built HTML in doc/_build/html to the gh-pages branch
     - provider: script
       script: continuous-integration/travis/deploy-gh-pages.sh
-      cleanup: false
+      skip_cleanup: true
       on:
           branch: master
           condition: '$DEPLOY_DOCS == "true"'
     # Push HTML when building tags as well
     - provider: script
       script: continuous-integration/travis/deploy-gh-pages.sh
-      cleanup: false
+      skip_cleanup: true
       on:
           tags: true
           condition: '$DEPLOY_DOCS == "true"'


### PR DESCRIPTION
The built HTML was being deleted. This is because a while back Travis
changed the variable `cleanup: false` to `skip_cleanup: true`...

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] If adding new example, please build the docs with `make -C doc gallery` and push the changes made on `doc/gallery`. Continuous Integration services build and deploy the docs, but they won't run the examples.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.


**Reminders for Maintainers**:

- [ ] Maintainers **must** run all tests locally before the PR is merged. CIs run only minimal tests and styling checks.
