### PR TITLE
Disable release drafter on forks & update template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,31 +1,31 @@
 # Configuration for the Release Drafter workflow
 name-template: 'v$NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
-change-template: '* $TITLE (#$NUMBER by [@$AUTHOR](https://github.com/$AUTHOR))'
+change-template: '* $TITLE (#$NUMBER)'
 categories:
-  - title: 'New functions/classes'
+  - title: 'New functions/classes:'
     label: 'feature'
-  - title: 'Enhancements'
+  - title: 'Enhancements:'
     label: 'enhancement'
-  - title: 'Bug fixes'
+  - title: 'Bug fixes:'
     label: 'bug'
-  - title: 'Deprecations'
+  - title: 'Deprecations:'
     label: 'deprecation'
-  - title: 'Documentation'
+  - title: 'Backwards incompatible:'
+    label: 'breaking change'
+  - title: 'Documentation:'
     label: 'documentation'
-  - title: 'Maintenance'
+  - title: 'Maintenance:'
     label: 'maintenance'
 exclude-labels:
   - 'skip-changelog'
 template: |
   [![DOI](https://zenodo.org/badge/DOI/PASTE_DOI_HERE.svg)](https://doi.org/PASTE_DOI_HERE)
 
-  ## Highlights
+  ## Highlights:
 
   * DELETE IF THERE ARE NO HIGHLIGHTS
 
   $CHANGES
 
-  ## Contributors
-
-  $CONTRIBUTORS
+  **This release contains contributions from:** $CONTRIBUTORS

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,12 +12,14 @@ on:
 
 jobs:
   update_release_draft:
+    # Prevent release drafter from making draft releases in forks
+    if: github.repository == 'fatiando/rockhound'
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5
         with:
-          # config name to use, relative to .github/
+          # Configuration file, relative to .github/
           config-name: release-drafter.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Remove the repeated appearance of PR authors (leave only the end list),
disable running the workflow on forks (and creating drafts on them), add
the new "breaking change" label.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] If adding new example, please build the docs with `make -C doc gallery` and push the changes made on `doc/gallery`. Continuous Integration services build and deploy the docs, but they won't run the examples.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.


**Reminders for Maintainers**:

- [ ] Maintainers **must** run all tests locally before the PR is merged. CIs run only minimal tests and styling checks.
